### PR TITLE
added namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Change Log
 
+## [0.7.0] - Released on 2019-10-19
+
+- Added `namespace` to support multiple instances
+- Breaking Changes:
+  - Removed static `CacheStore.setPolicy` method
+  - Moved `CacheStore.fetch` to instance field
+  - Renamed `CacheStore.getInstance` parameter `httpGetter` to `fetch`
+
+### Upgrade Guide
+
+1. remove `CacheStore.setPolicy` and set the policy in `CacheStore.getInstance`. For example, `CacheStore.getInstance(policy: LessRecentlyUsedPolicy(maxCount: 4096))`
+2. if `httpGetter: myFetch` is used in `CacheStore.getInstance`, rename it to `fetch: myFetch`
+3. any `CacheStore.fetch = myFetch` should be `store.fetch = myFetch`
+
+For instance, old API:
+
+```diff
+void foo() async {
+- CacheStore.setPolicy(LessRecentlyUsedPolicy(maxCount: 4096)); // 1
+  CacheStore store = await CacheStore.getInstance(
++   policy: LessRecentlyUsedPolicy(maxCount: 4096), // 1
+    clearNow: true,
+-   httpGetter: bar, // 2
++   fetch: bar, // 2
+  );
+
+- CacheStore.fetch = baz; // 3
++ store.fetch = baz; // 3
+}
+```
+
 ## [0.6.0] - Released on 2019-07-08
 
 - Fixed a bug `CacheStore.fetch` not working.

--- a/README.md
+++ b/README.md
@@ -24,21 +24,17 @@ void demo(String url) async {
 
 ```dart
 void api() async {
-  // set expiration policy.
-  // must be called before `CacheStore.getInstance` or will raise an exception.
-  // default: LessRecentlyUsedPolicy(maxCount: 999)
-  CacheStore.setPolicy(LessRecentlyUsedPolicy(maxCount: 4096));
-
-  // get a singleton store instance
+  // get store instance
   CacheStore store = await CacheStore.getInstance(
+    namespace: 'unique_name', // default: null - valid filename used as unique id
+    policy: LeastFrequentlyUsedPolicy(), // default: null - will use `LessRecentlyUsedPolicy()`
     clearNow: true, // default: false - whether to clean up immediately
-    httpGetter: myFetch, // default: null - a shortcut of `CacheStore.fetch`
+    fetch: myFetch, // default: null - a shortcut of `CacheStore.fetch`
   );
 
-  // Optional:
   // You can change custom fetch method at anytime.
   // Set it to `null` will simply use `http.get`
-  CacheStore.fetch = myFetch;
+  store.fetch = myFetch;
 
   // fetch a file from an URL and cache it
   File file = await store.getFile(
@@ -95,11 +91,11 @@ class LRUCachePolicy extends LessRecentlyUsedPolicy {
 }
 
 void customizedCacheFileStructure() async {
-  // Set it as your Policy
-  CacheStore.setPolicy(LRUCachePolicy(maxCount: 4096));
-
-  // get a singleton store instance
-  CacheStore store = await CacheStore.getInstance();
+  // get store instance
+  CacheStore store = await CacheStore.getInstance(
+    policy: LRUCachePolicy(maxCount: 4096),
+    namespace: 'my_store',
+  );
 
   // fetch a file from an URL and cache it
   String bookId = 'book123';
@@ -110,7 +106,7 @@ void customizedCacheFileStructure() async {
     key: '$bookId/$chapterId', // use IDs as path and filename
   );
 
-  // Your file will be cached as `$TEMP/cache_store/book123/ch42`
+  // Your file will be cached as `$TEMP/cache_store__my_store/book123/ch42`
 }
 ```
 
@@ -156,8 +152,8 @@ void customizedCacheFileStructure() async {
   First-In, First-Out policy, super simple and maybe for example only.
 
   ```dart
-  new LessRecentlyUsedPolicy(
-    maxCount: 999, // default: 999
+  new FifoPolicy(
+    maxCount: 999,
   );
   ```
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -11,21 +11,19 @@ void demo(String url) async {
 
 // [BASIC OPTIONS]
 void api() async {
-  // set expiration policy.
-  // must be called before `CacheStore.getInstance` or will raise an exception.
-  // default: LessRecentlyUsedPolicy(maxCount: 999)
-  CacheStore.setPolicy(LessRecentlyUsedPolicy(maxCount: 4096));
-
-  // get a singleton store instance
+  // get store instance
   CacheStore store = await CacheStore.getInstance(
+    namespace:
+        'unique_name', // default: null - valid filename used as unique id
+    policy:
+        LeastFrequentlyUsedPolicy(), // default: null - will use `LessRecentlyUsedPolicy()`
     clearNow: true, // default: false - whether to clean up immediately
-    httpGetter: myFetch, // default: null - a shortcut of `CacheStore.fetch`
+    fetch: myFetch, // default: null - a shortcut of `CacheStore.fetch`
   );
 
-  // Optional:
   // You can change custom fetch method at anytime.
   // Set it to `null` will simply use `http.get`
-  CacheStore.fetch = myFetch;
+  store.fetch = myFetch;
 
   // fetch a file from an URL and cache it
   File file = await store.getFile(
@@ -73,11 +71,11 @@ class LRUCachePolicy extends LessRecentlyUsedPolicy {
 }
 
 void customizedCacheFileStructure() async {
-  // Set it as your Policy
-  CacheStore.setPolicy(LRUCachePolicy(maxCount: 4096));
-
-  // get a singleton store instance
-  CacheStore store = await CacheStore.getInstance();
+  // get store instance
+  CacheStore store = await CacheStore.getInstance(
+    policy: LRUCachePolicy(maxCount: 4096),
+    namespace: 'my_store',
+  );
 
   // fetch a file from an URL and cache it
   String bookId = 'book123';
@@ -88,5 +86,5 @@ void customizedCacheFileStructure() async {
     key: '$bookId/$chapterId', // use IDs as path and filename
   );
 
-  // Your file will be cached as `$TEMP/cache_store/book123/ch42`
+  // Your file will be cached as `$TEMP/cache_store__my_store/book123/ch42`
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cache_store
 description: More configurable cache manager for Flutter. Cache http get requests to mobile devices file system.
-version: 0.6.0
+version: 0.7.0
 author: eGust<egustc@gmail.com>
 homepage: https://github.com/eGust/flutter_cache_store
 


### PR DESCRIPTION
## [0.7.0] - to be tested

- Added `namespace` to support multiple instances
- Breaking Changes:
  - Removed static `CacheStore.setPolicy` method
  - Moved `CacheStore.fetch` to instance field
  - Renamed `CacheStore.getInstance` parameter `httpGetter` to `fetch`

### Upgrade Guide

1. remove `CacheStore.setPolicy` and set the policy in `CacheStore.getInstance`. For example, `CacheStore.getInstance(policy: LessRecentlyUsedPolicy(maxCount: 4096))`
2. if `httpGetter: myFetch` is used in `CacheStore.getInstance`, rename it to `fetch: myFetch`
3. any `CacheStore.fetch = myFetch` should be `store.fetch = myFetch`

For instance, old API:

```diff
void foo() async {
- CacheStore.setPolicy(LessRecentlyUsedPolicy(maxCount: 4096)); // 1
  CacheStore store = await CacheStore.getInstance(
+   policy: LessRecentlyUsedPolicy(maxCount: 4096), // 1
    clearNow: true,
-   httpGetter: bar, // 2
+   fetch: bar, // 2
  );

- CacheStore.fetch = baz; // 3
+ store.fetch = baz; // 3
}
```